### PR TITLE
FIX: enhanced lazy loading in the OData package

### DIFF
--- a/django_odata/__init__.py
+++ b/django_odata/__init__.py
@@ -8,14 +8,13 @@ This package combines drf-flex-fields and odata-query to provide:
 - Extensible architecture for custom OData features
 """
 
+from importlib import import_module
+from typing import Any
+
 __version__ = "0.1.0"
 __author__ = "Your Name"
 
-from .mixins import ODataMixin, ODataSerializerMixin
-from .serializers import ODataModelSerializer, ODataSerializer
-from .utils import apply_odata_query_params, parse_odata_query
-from .viewsets import ODataModelViewSet, ODataViewSet
-
+# Public API (resolved lazily to avoid importing Django/DRF at import time)
 __all__ = [
     "ODataModelSerializer",
     "ODataSerializer",
@@ -26,3 +25,35 @@ __all__ = [
     "apply_odata_query_params",
     "parse_odata_query",
 ]
+
+
+_NAME_TO_MODULE = {
+    # mixins
+    "ODataMixin": "django_odata.mixins",
+    "ODataSerializerMixin": "django_odata.mixins",
+    # serializers
+    "ODataModelSerializer": "django_odata.serializers",
+    "ODataSerializer": "django_odata.serializers",
+    # utils
+    "apply_odata_query_params": "django_odata.utils",
+    "parse_odata_query": "django_odata.utils",
+    # viewsets
+    "ODataModelViewSet": "django_odata.viewsets",
+    "ODataViewSet": "django_odata.viewsets",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """
+    Lazily resolve attributes from submodules to prevent importing Django/DRF
+    at package import time. This helps avoid touching app models/settings
+    before Django apps are ready.
+    """
+    if name in _NAME_TO_MODULE:
+        module = import_module(_NAME_TO_MODULE[name])
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 DJANGO_SETTINGS_MODULE = tests.integration.support.settings
 python_files = tests.py test_*.py *_tests.py
 addopts = --verbose --tb=short


### PR DESCRIPTION
Introduced lazy loading for public API attributes in django_odata.__init__.py to prevent early imports of Django/DRF, improving package initialization.